### PR TITLE
Xygeni-Bumper - com.thoughtworks.xstream:xstream from 1.4.5 to 1.4.14-jdk7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <webwolf.port>9090</webwolf.port>
     <wiremock.version>3.13.0</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.14-jdk7</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.9.0</zxcvbn.version>
   </properties>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.14-jdk7 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.14-jdk7 
### 📝 Description 

CVE-2020-26217 XStream before version 1.4.14 is vulnerable to Remote Code Execution.The vulnerability may allow a remote attacker to run arbitrary shell commands only by manipulating the processed input stream. Only users who rely on blocklists are affected. Anyone using XStream's Security Framework allowlist is not affected. The linked advisory provides code workarounds for users who cannot upgrade. The issue is fixed in version 1.4.14. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2020-26217 



