### PR TITLE
xygeni SAST java.sql_injection ...d/SqlInjectionLesson6a.java 72

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java
@@ -8,10 +8,10 @@ import static org.owasp.webgoat.container.assignments.AttackResultBuilder.failed
 import static org.owasp.webgoat.container.assignments.AttackResultBuilder.success;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
 import org.owasp.webgoat.container.LessonDataSource;
 import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AssignmentHints;
@@ -51,9 +51,9 @@ public class SqlInjectionLesson6a implements AssignmentEndpoint {
     String query = "";
     try (Connection connection = dataSource.getConnection()) {
       boolean usedUnion = this.unionQueryChecker(accountName);
-      query = "SELECT * FROM user_data WHERE last_name = '" + accountName + "'";
-
-      return executeSqlInjection(connection, query, usedUnion);
+      query = "SELECT * FROM user_data WHERE last_name = ?";
+      
+      return executeSqlInjection(connection, query, usedUnion, accountName);
     } catch (Exception e) {
       return failed(this)
           .output(this.getClass().getName() + " : " + e.getMessage() + YOUR_QUERY_WAS + query)
@@ -65,12 +65,12 @@ public class SqlInjectionLesson6a implements AssignmentEndpoint {
     return accountName.matches("(?i)(^[^-/*;)]*)(\\s*)UNION(.*$)");
   }
 
-  private AttackResult executeSqlInjection(Connection connection, String query, boolean usedUnion) {
-    try (Statement statement =
-        connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
-
-      ResultSet results = statement.executeQuery(query);
-
+  private AttackResult executeSqlInjection(Connection connection, String query, boolean usedUnion, String accountName) {
+    try (PreparedStatement statement = connection.prepareStatement(query, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+      statement.setString(1, accountName);
+      
+      ResultSet results = statement.executeQuery();
+      
       if (!((results != null) && results.first())) {
         return failed(this)
             .feedback("sql-injection.advanced.6a.no.results")


### PR DESCRIPTION
The SQL injection vulnerability was fixed by replacing the `Statement` with a `PreparedStatement`. The query was modified to use a parameter placeholder (`?`) for the `accountName` value, and the `accountName` is set using `statement.setString(1, accountName)`. This approach prevents SQL injection by ensuring that user input is treated as a parameter rather than executable SQL code.