### PR TITLE
xygeni SAST java.cross_site_scripting .../LessonProgressService.java 44

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/service/LessonProgressService.java
+++ b/src/main/java/org/owasp/webgoat/container/service/LessonProgressService.java
@@ -40,8 +40,14 @@ public class LessonProgressService {
 
     var lessonProgress = userProgress.getLessonProgress(lesson);
     return lessonProgress.getLessonOverview().entrySet().stream()
-        .map(entry -> new LessonOverview(entry.getKey().getAssignment(), entry.getValue()))
+        .map(entry -> new LessonOverview(escapeHtml(entry.getKey().getAssignment()), entry.getValue()))
         .toList();
+  }
+
+  private String escapeHtml(Assignment assignment) {
+    // Assuming Assignment has a method to get its name or description
+    // Implement escaping logic here, for example using Apache Commons Text
+    return org.apache.commons.text.StringEscapeUtils.escapeHtml4(assignment.toString());
   }
 
   @AllArgsConstructor
@@ -51,7 +57,7 @@ public class LessonProgressService {
   // so creating intermediate object is the easiest solution
   private static class LessonOverview {
 
-    private Assignment assignment;
+    private String assignment;
     private Boolean solved;
   }
 }


### PR DESCRIPTION
To fix the cross-site scripting (XSS) vulnerability, the code now includes an `escapeHtml` method that escapes HTML characters in the `Assignment` object before it is used in the `LessonOverview`. This prevents any HTML or JavaScript code from being executed in the user's browser. The `escapeHtml` method uses Apache Commons Text's `StringEscapeUtils.escapeHtml4` to perform the escaping. This ensures that any potentially harmful input is rendered harmless by converting it to a safe string representation.