### PR TITLE
xygeni SAST java.sql_injection ...iner/users/UserService.java 53

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/users/UserService.java
+++ b/src/main/java/org/owasp/webgoat/container/users/UserService.java
@@ -50,8 +50,9 @@ public class UserService implements UserDetailsService {
   }
 
   private void createLessonsForUser(WebGoatUser webGoatUser) {
-    jdbcTemplate.execute("CREATE SCHEMA \"" + webGoatUser.getUsername() + "\" authorization dba");
-    flywayLessons.apply(webGoatUser.getUsername()).migrate();
+    String schemaName = webGoatUser.getUsername();
+    jdbcTemplate.execute("CREATE SCHEMA \"" + schemaName.replace("\"", "\"\"") + "\" authorization dba");
+    flywayLessons.apply(schemaName).migrate();
   }
 
   public List<WebGoatUser> getAllUsers() {


### PR DESCRIPTION
To fix the SQL injection vulnerability at line 53, the code now sanitizes the `schemaName` by replacing any double quotes with two double quotes. This prevents an attacker from injecting malicious SQL through the `username`. This approach is a simple way to handle potential SQL injection in this context, given the lack of parameterized queries for schema creation in this setup.