### PR TITLE
xygeni SAST java.sql_injection .../SqlInjectionChallenge.java 57

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
@@ -51,10 +51,10 @@ public class SqlInjectionChallenge implements AssignmentEndpoint {
     if (attackResult == null) {
 
       try (Connection connection = dataSource.getConnection()) {
-        String checkUserQuery =
-            "select userid from sql_challenge_users where userid = '" + username + "'";
-        Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(checkUserQuery);
+        String checkUserQuery = "select userid from sql_challenge_users where userid = ?";
+        PreparedStatement statement = connection.prepareStatement(checkUserQuery);
+        statement.setString(1, username);
+        ResultSet resultSet = statement.executeQuery();
 
         if (resultSet.next()) {
           attackResult = failed(this).feedback("user.exists").feedbackArgs(username).build();


### PR DESCRIPTION
The SQL injection vulnerability at line 57 was fixed by replacing the `Statement` with a `PreparedStatement`. The query was modified to use a parameterized query with a placeholder (`?`) for the `username`. This change ensures that the input is treated as a parameter rather than part of the SQL command, effectively preventing SQL injection attacks.