### PR TITLE
xygeni SAST java.weak_password_hash ...iner/WebSecurityConfig.java 88

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/WebSecurityConfig.java
+++ b/src/main/java/org/owasp/webgoat/container/WebSecurityConfig.java
@@ -16,7 +16,8 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 /** Security configuration for WebGoat. */
@@ -84,7 +85,7 @@ public class WebSecurityConfig {
   }
 
   @Bean
-  public NoOpPasswordEncoder passwordEncoder() {
-    return (NoOpPasswordEncoder) NoOpPasswordEncoder.getInstance();
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
   }
 }


### PR DESCRIPTION
The code was using `NoOpPasswordEncoder`, which does not apply any hashing to passwords, making it insecure. To fix this, I replaced it with `BCryptPasswordEncoder`, a more secure password encoder that applies a strong hashing algorithm (BCrypt) to passwords. This change enhances the security of password storage by ensuring that passwords are hashed before being stored, making it more difficult for attackers to retrieve the original passwords even if they gain access to the stored data.