### PR TITLE
xygeni SAST javascript.cross_site_scripting ...s/lessons/jwt/js/jwt-jku.js 6

### DIFF
--- a/src/main/resources/lessons/jwt/js/jwt-jku.js
+++ b/src/main/resources/lessons/jwt/js/jwt-jku.js
@@ -1,8 +1,8 @@
 function follow(user) {
     $.ajax({
         type: 'POST',
-        url: 'JWT/kid/follow/' + user
+        url: 'JWT/kid/follow/' + encodeURIComponent(user)
     }).then(function (result) {
-        $("#toast").append(result);
+        $("#toast").text(result);
     })
 }


### PR DESCRIPTION
<h2>Fixed issue javascript.cross_site_scripting in src/main/resources/lessons/jwt/js/jwt-jku.js at line 6</h2><br/>To prevent cross-site scripting (XSS), the user input is sanitized using `encodeURIComponent` to ensure that any special characters in the `user` variable are properly encoded. Additionally, instead of using `append`, which can introduce HTML content directly, `text` is used to safely insert the result as plain text, preventing any potential execution of malicious scripts.<br/>