### PR TITLE
xygeni SAST java.xml_entity_injection ...sons/xxe/CommentsCache.java 79

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -70,10 +70,10 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    // TODO fix me disabled for now.
     if (securityEnabled) {
       xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
       xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
+      xif.setProperty(XMLInputFactory.SUPPORT_DTD, false); // Disable DTDs entirely
     }
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));


### PR DESCRIPTION
<h2>Fixed issue java.xml_entity_injection in src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java at line 79</h2><br/>To fix the XML External Entity (XXE) injection vulnerability, the code now includes a line to disable DTDs entirely by setting the `XMLInputFactory.SUPPORT_DTD` property to `false`. This prevents any external entity definitions from being processed, which is a common vector for XXE attacks. This change is applied when `securityEnabled` is true, ensuring that the XML parsing is secure when needed.<br/>